### PR TITLE
update for Clickhouse distributed case

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -30,7 +30,7 @@
  <check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
   <parameters>
-   <parameter name="maxLineLength"><![CDATA[160]]></parameter>
+   <parameter name="maxLineLength"><![CDATA[300]]></parameter>
    <parameter name="tabSize"><![CDATA[4]]></parameter>
   </parameters>
  </check>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -30,7 +30,7 @@
  <check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
   <parameters>
-   <parameter name="maxLineLength"><![CDATA[300]]></parameter>
+   <parameter name="maxLineLength"><![CDATA[160]]></parameter>
    <parameter name="tabSize"><![CDATA[4]]></parameter>
   </parameters>
  </check>

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/output/batch/Clickhouse.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/output/batch/Clickhouse.scala
@@ -3,29 +3,21 @@ package io.github.interestinglab.waterdrop.output.batch
 import java.text.SimpleDateFormat
 import java.util
 import java.util.Properties
-import java.math.BigDecimal
 import java.sql.ResultSet
 
 import io.github.interestinglab.waterdrop.config.{Config, ConfigFactory}
 import io.github.interestinglab.waterdrop.apis.BaseOutput
 import io.github.interestinglab.waterdrop.config.ConfigRuntimeException
 import io.github.interestinglab.waterdrop.config.TypesafeConfigUtils
+import io.github.interestinglab.waterdrop.output.utils.{ClickhouseUtil, ClickhouseUtilParam}
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
-import ru.yandex.clickhouse.except.{ClickHouseException, ClickHouseUnknownException}
 import ru.yandex.clickhouse.settings.ClickHouseProperties
-import ru.yandex.clickhouse.{
-  BalancedClickhouseDataSource,
-  ClickHouseConnectionImpl,
-  ClickHousePreparedStatement,
-  ClickhouseJdbcUrlParser
-}
+import ru.yandex.clickhouse.{BalancedClickhouseDataSource, ClickHouseConnectionImpl, ClickHouseStatement, ClickhouseJdbcUrlParser}
 
 import scala.collection.JavaConversions._
 import scala.collection.immutable.HashMap
 import scala.collection.mutable.ArrayBuffer
-import scala.collection.mutable.WrappedArray
 import scala.util.matching.Regex
-import scala.util.{Failure, Success, Try}
 
 class Clickhouse extends BaseOutput {
 
@@ -33,12 +25,19 @@ class Clickhouse extends BaseOutput {
   var jdbcLink: String = _
   var initSQL: String = _
   var table: String = _
+  var localTable: String = _
   var fields: java.util.List[String] = _
 
   var cluster: String = _
 
-  //contians cluster basic info
-  var clusterInfo: ArrayBuffer[(String, Int, Int, String)] = _
+  //contains cluster basic info
+  var clusterInfo: ArrayBuffer[(String, Int, Int, String, Int)] = _
+  // for distributed table, parse out the shardKey
+  private val Distributed = "Distributed"
+  private val rand = "rand()"
+  private val intHash = "intHash"
+  private val brackets = ")"
+  private var shardingKey: String = _
 
   var retryCodes: java.util.List[Integer] = _
   var config: Config = ConfigFactory.empty()
@@ -134,17 +133,74 @@ class Clickhouse extends BaseOutput {
       this.cluster = config.getString("cluster")
 
       this.clusterInfo = getClickHouseClusterInfo(conn, cluster)
-      if (this.clusterInfo.size == 0) {
+      if (this.clusterInfo.isEmpty) {
         val errorInfo = s"cloud not find cluster config in system.clusters, config cluster = $cluster"
         logError(errorInfo)
         throw new RuntimeException(errorInfo)
       }
       logInfo(s"get [$cluster] config from system.clusters, the replica info is [$clusterInfo].")
+      verifyTableEngine(table, conn)
+    } else {
+      val tuples: ArrayBuffer[(String, Int, Int, String, Int)] = ArrayBuffer[(String, Int, Int, String, Int)]()
+      tuples += Tuple5("", 1, 1, config.getString("host"), getJDBCPort(jdbcLink))
+      this.clusterInfo = tuples
     }
 
     config = config.withFallback(defaultConfig)
     retryCodes = config.getIntList("retry_codes")
     super.prepare(spark)
+  }
+
+  /**
+   * now use table DDL get the sharding key or other setting, because now it not has other solution
+   * if feature has better way to get it this method should be replace
+   *
+   * @param tableName
+   * @param conn
+   */
+  private def verifyTableEngine(tableName: String, conn: ClickHouseConnectionImpl): Unit = {
+    val showCreateTable = s"show create table $tableName}"
+    val statement: ClickHouseStatement = conn.createStatement()
+    val tableDDLRS: ResultSet = statement.executeQuery(showCreateTable)
+    var tableDDLString: String = ""
+    while (tableDDLRS.next()) {
+      tableDDLString = tableDDLRS.getString(1)
+    }
+    // if table use distributed engine, get the sharding key.
+    if (tableDDLString.contains(Distributed)) {
+      val subIndex: Int = tableDDLString.indexOf(Distributed) + Distributed.length + 1
+      val configSettings: String = tableDDLString.substring(subIndex)
+      var endIndex: Int = configSettings.indexOf(brackets)
+      if (configSettings.contains(intHash)) {
+        // if use intHash as the sharding key, setting would like this
+        // Distributed('cluster_name','database_name','remote_table_name',intHash64(shardingKey)[,policy_name])
+        val errorInfo = "Currently does not support intHash as a sharding strategy!"
+        throw new RuntimeException(errorInfo)
+      }
+      val distributedSettings: String = configSettings.substring(0, endIndex).replace("'", "")
+      val settings: Array[String] = distributedSettings.split(",")
+      // if remote table's cluster is different with distributed table, rebuild cluster info
+      if (settings(0).trim != cluster) {
+        this.clusterInfo = getClickHouseClusterInfo(conn, settings(0))
+      }
+      // if remote table's database is different with distributed table's database, rebuild jdbc url
+      if (settings(1).trim != config.getString("database")) {
+        this.jdbcLink.replace(config.getString("database"), settings(1))
+      }
+      localTable = settings(2).trim
+      // not setting sharding key, means only can insert to one node, same as stand-alone mode, if remote_table on multiple node, will get error
+      if (settings.length == 3) {
+        shardingKey = null
+      }
+      // Distributed(cluster_name, database_name, remote_table_name[,policy_name]) or Distributed(cluster_name, database_name, remote_table_name,rand()[,policy_name])
+      val shardingKeySetting: String = settings(3).trim
+      if (shardingKeySetting.equals(rand)) {
+        shardingKey = rand
+      } else {
+        shardingKey = shardingKeySetting
+      }
+    }
+    statement.close()
   }
 
   override def process(df: Dataset[Row]): Unit = {
@@ -159,42 +215,18 @@ class Clickhouse extends BaseOutput {
     this.initSQL = initPrepareSQL()
     logInfo(this.initSQL)
 
-    df.foreachPartition { iter =>
-      var jdbcUrl = this.jdbcLink
-      if (this.clusterInfo != null && this.clusterInfo.size > 0) {
-        //using random policy to select shard when insert data
-        val randomShard = (Math.random() * this.clusterInfo.size).asInstanceOf[Int]
-        val shardInfo = this.clusterInfo.get(randomShard)
-
-        val host = shardInfo._4
-        val port = getJDBCPort(this.jdbcLink)
-        val database = config.getString("database")
-
-        jdbcUrl = s"jdbc:clickhouse://$host:$port/$database"
-        logInfo(s"cluster mode, select shard index [$randomShard] to insert data, the jdbc url is [$jdbcUrl].")
-      } else {
-        logInfo(s"single mode, the jdbc url is [$jdbcUrl].")
-      }
-
-      val executorBalanced = new BalancedClickhouseDataSource(jdbcUrl, this.properties)
-      val executorConn = executorBalanced.getConnection.asInstanceOf[ClickHouseConnectionImpl]
-      val statement = executorConn.createClickHousePreparedStatement(this.initSQL, ResultSet.TYPE_FORWARD_ONLY)
-      var length = 0
-      while (iter.hasNext) {
-        val row = iter.next()
-        length += 1
-
-        renderStatement(fields, row, dfFields, statement)
-        statement.addBatch()
-
-        if (length >= bulkSize) {
-          execute(statement, retry)
-          length = 0
-        }
-      }
-
-      execute(statement, retry)
+    var finalDf: Dataset[Row] = null
+    if (shardingKey != null && shardingKey != rand) {
+      finalDf = df.repartition(df(shardingKey))
+    } else {
+      finalDf = df
     }
+    val param: ClickhouseUtilParam = ClickhouseUtilParam(clusterInfo, config.getString("database"), config.getString("username"), config.getString("password"), initSQL, tableSchema, fields.toList, shardingKey, bulkSize, retry, retryCodes.toList)
+    finalDf.foreachPartition(partitionData => {
+      val clickhouseUtil = new ClickhouseUtil(param)
+      clickhouseUtil.insertData(partitionData)
+    })
+
   }
 
   private def getJDBCPort(jdbcUrl: String): Int = {
@@ -202,36 +234,6 @@ class Clickhouse extends BaseOutput {
     clickHouseProperties.getPort
   }
 
-  private def execute(statement: ClickHousePreparedStatement, retry: Int): Unit = {
-    val res = Try(statement.executeBatch())
-    res match {
-      case Success(_) => {
-        logInfo("Insert into ClickHouse succeed")
-        statement.close()
-      }
-      case Failure(e: ClickHouseException) => {
-        val errorCode = e.getErrorCode
-        if (retryCodes.contains(errorCode)) {
-          logError("Insert into ClickHouse failed. Reason: ", e)
-          if (retry > 0) {
-            execute(statement, retry - 1)
-          } else {
-            logError("Insert into ClickHouse failed and retry failed, drop this bulk.")
-            statement.close()
-          }
-        } else {
-          throw e
-        }
-      }
-      case Failure(e: ClickHouseUnknownException) => {
-        statement.close()
-        throw e
-      }
-      case Failure(e: Exception) => {
-        throw e
-      }
-    }
-  }
 
   private def getClickHouseSchema(conn: ClickHouseConnectionImpl, table: String): Map[String, String] = {
     val sql = s"desc $table"
@@ -243,14 +245,12 @@ class Clickhouse extends BaseOutput {
     schema
   }
 
-  private def getClickHouseClusterInfo(
-    conn: ClickHouseConnectionImpl,
-    cluster: String): ArrayBuffer[(String, Int, Int, String)] = {
+  private def getClickHouseClusterInfo(conn: ClickHouseConnectionImpl, cluster: String): ArrayBuffer[(String, Int, Int, String, Int)] = {
     val sql =
-      s"SELECT cluster, shard_num, shard_weight, host_address FROM system.clusters WHERE cluster = '$cluster' AND replica_num = 1"
+      s"SELECT cluster, shard_num, shard_weight, host_address FROM system.clusters WHERE cluster = '$cluster' AND replica_num = 1 order by shard_num"
     val resultSet = conn.createStatement.executeQuery(sql)
 
-    val clusterInfo = ArrayBuffer[(String, Int, Int, String)]()
+    val clusterInfo = ArrayBuffer[(String, Int, Int, String, Int)]()
     while (resultSet.next()) {
       val shardWeight = resultSet.getInt("shard_weight")
       for (_ <- 1 to shardWeight) {
@@ -258,8 +258,8 @@ class Clickhouse extends BaseOutput {
         val custerName = resultSet.getString("cluster")
         val shardNum = resultSet.getInt("shard_num")
         val hostAddress = resultSet.getString("host_address")
-
-        val shardInfo = Tuple4(custerName, shardNum, shardWeight, hostAddress)
+        val port: Int = getJDBCPort(jdbcLink)
+        val shardInfo: (String, Int, Int, String, Int) = Tuple5(custerName, shardNum, shardWeight, hostAddress, port)
         clusterInfo += shardInfo
       }
     }
@@ -268,9 +268,15 @@ class Clickhouse extends BaseOutput {
 
   private def initPrepareSQL(): String = {
     val prepare = List.fill(fields.size)("?")
+    var finalTable = ""
+    if (shardingKey != null) {
+      finalTable = this.localTable
+    } else {
+      finalTable = this.table
+    }
     val sql = String.format(
       "insert into %s (%s) values (%s)",
-      this.table,
+      finalTable,
       this.fields.map(a => s"`$a`").mkString(","),
       prepare.mkString(","))
 
@@ -305,106 +311,6 @@ class Clickhouse extends BaseOutput {
     }
   }
 
-  private def renderDefaultStatement(index: Int, fieldType: String, statement: ClickHousePreparedStatement): Unit = {
-    fieldType match {
-      case "DateTime" | "Date" | "String" =>
-        statement.setString(index + 1, Clickhouse.renderStringDefault(fieldType))
-      case "Int8" | "UInt8" | "Int16" | "Int32" | "UInt32" | "UInt16" =>
-        statement.setInt(index + 1, 0)
-      case "UInt64" | "Int64" =>
-        statement.setLong(index + 1, 0)
-      case "Float32" => statement.setFloat(index + 1, 0)
-      case "Float64" => statement.setDouble(index + 1, 0)
-      case Clickhouse.lowCardinalityPattern(lowCardinalityType) =>
-        renderDefaultStatement(index, lowCardinalityType, statement)
-      case Clickhouse.arrayPattern(_) => statement.setArray(index + 1, List())
-      case Clickhouse.nullablePattern(nullFieldType) => renderNullStatement(index, nullFieldType, statement)
-      case _ => statement.setString(index + 1, "")
-    }
-  }
-
-  private def renderNullStatement(index: Int, fieldType: String, statement: ClickHousePreparedStatement): Unit = {
-    fieldType match {
-      case "String" =>
-        statement.setNull(index + 1, java.sql.Types.VARCHAR)
-      case "DateTime" => statement.setNull(index + 1, java.sql.Types.DATE)
-      case "Date" => statement.setNull(index + 1, java.sql.Types.TIME)
-      case "Int8" | "UInt8" | "Int16" | "Int32" | "UInt32" | "UInt16" =>
-        statement.setNull(index + 1, java.sql.Types.INTEGER)
-      case "UInt64" | "Int64" =>
-        statement.setNull(index + 1, java.sql.Types.BIGINT)
-      case "Float32" => statement.setNull(index + 1, java.sql.Types.FLOAT)
-      case "Float64" => statement.setNull(index + 1, java.sql.Types.DOUBLE)
-      case "Array" => statement.setNull(index + 1, java.sql.Types.ARRAY)
-      case Clickhouse.decimalPattern(_) => statement.setNull(index + 1, java.sql.Types.DECIMAL)
-    }
-  }
-
-  private def renderBaseTypeStatement(
-    index: Int,
-    fieldIndex: Int,
-    fieldType: String,
-    item: Row,
-    statement: ClickHousePreparedStatement): Unit = {
-    fieldType match {
-      case "DateTime" | "Date" | "String" =>
-        statement.setString(index + 1, item.getAs[String](fieldIndex))
-      case "Int8" | "UInt8" | "Int16" | "UInt16" | "Int32" =>
-        statement.setInt(index + 1, item.getAs[Int](fieldIndex))
-      case "UInt32" | "UInt64" | "Int64" =>
-        statement.setLong(index + 1, item.getAs[Long](fieldIndex))
-      case "Float32" => statement.setFloat(index + 1, item.getAs[Float](fieldIndex))
-      case "Float64" => statement.setDouble(index + 1, item.getAs[Double](fieldIndex))
-      case Clickhouse.arrayPattern(_) =>
-        statement.setArray(index + 1, item.getAs[WrappedArray[AnyRef]](fieldIndex))
-      case "Decimal" => statement.setBigDecimal(index + 1, item.getAs[BigDecimal](fieldIndex))
-      case _ => statement.setString(index + 1, item.getAs[String](fieldIndex))
-    }
-  }
-
-  private def renderStatementEntry(
-    index: Int,
-    fieldIndex: Int,
-    fieldType: String,
-    item: Row,
-    statement: ClickHousePreparedStatement): Unit = {
-    fieldType match {
-      case "String" | "DateTime" | "Date" | Clickhouse.arrayPattern(_) =>
-        renderBaseTypeStatement(index, fieldIndex, fieldType, item, statement)
-      case Clickhouse.floatPattern(_) | Clickhouse.intPattern(_) | Clickhouse.uintPattern(_) =>
-        renderBaseTypeStatement(index, fieldIndex, fieldType, item, statement)
-      case Clickhouse.nullablePattern(dataType) =>
-        renderStatementEntry(index, fieldIndex, dataType, item, statement)
-      case Clickhouse.lowCardinalityPattern(dataType) =>
-        renderBaseTypeStatement(index, fieldIndex, dataType, item, statement)
-      case Clickhouse.decimalPattern(_) =>
-        renderBaseTypeStatement(index, fieldIndex, "Decimal", item, statement)
-      case _ => statement.setString(index + 1, item.getAs[String](fieldIndex))
-    }
-  }
-
-  private def renderStatement(
-    fields: util.List[String],
-    item: Row,
-    dsFields: Array[String],
-    statement: ClickHousePreparedStatement): Unit = {
-    for (i <- 0 until fields.size()) {
-      val field = fields.get(i)
-      val fieldType = tableSchema(field)
-      if (dsFields.indexOf(field) == -1) {
-        // specified field does not existed in row.
-        renderDefaultStatement(i, fieldType, statement)
-      } else {
-        val fieldIndex = item.fieldIndex(field)
-        if (item.isNullAt(fieldIndex)) {
-          // specified field is Null in Row.
-          renderDefaultStatement(i, fieldType, statement)
-        } else {
-          renderStatementEntry(i, fieldIndex, fieldType, item, statement)
-        }
-      }
-    }
-  }
 }
 
 object Clickhouse {

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/output/batch/Clickhouse.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/output/batch/Clickhouse.scala
@@ -12,7 +12,12 @@ import io.github.interestinglab.waterdrop.config.TypesafeConfigUtils
 import io.github.interestinglab.waterdrop.output.utils.{ClickhouseUtil, ClickhouseUtilParam}
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import ru.yandex.clickhouse.settings.ClickHouseProperties
-import ru.yandex.clickhouse.{BalancedClickhouseDataSource, ClickHouseConnectionImpl, ClickHouseStatement, ClickhouseJdbcUrlParser}
+import ru.yandex.clickhouse.{
+  BalancedClickhouseDataSource,
+  ClickHouseConnectionImpl,
+  ClickHouseStatement,
+  ClickhouseJdbcUrlParser
+}
 
 import scala.collection.JavaConversions._
 import scala.collection.immutable.HashMap
@@ -192,7 +197,8 @@ class Clickhouse extends BaseOutput {
       if (settings.length == 3) {
         shardingKey = null
       }
-      // Distributed(cluster_name, database_name, remote_table_name[,policy_name]) or Distributed(cluster_name, database_name, remote_table_name,rand()[,policy_name])
+      // Distributed(cluster_name, database_name, remote_table_name[,policy_name]) or
+      // Distributed(cluster_name, database_name, remote_table_name,rand()[,policy_name])
       val shardingKeySetting: String = settings(3).trim
       if (shardingKeySetting.equals(rand)) {
         shardingKey = rand
@@ -221,7 +227,19 @@ class Clickhouse extends BaseOutput {
     } else {
       finalDf = df
     }
-    val param: ClickhouseUtilParam = ClickhouseUtilParam(clusterInfo, config.getString("database"), config.getString("username"), config.getString("password"), initSQL, tableSchema, fields.toList, shardingKey, bulkSize, retry, retryCodes.toList)
+    val param: ClickhouseUtilParam = ClickhouseUtilParam(
+      clusterInfo,
+      config.getString("database"),
+      config.getString("username"),
+      config.getString("password"),
+      initSQL,
+      tableSchema,
+      fields.toList,
+      shardingKey,
+      bulkSize,
+      retry,
+      retryCodes.toList
+    )
     finalDf.foreachPartition(partitionData => {
       val clickhouseUtil = new ClickhouseUtil(param)
       clickhouseUtil.insertData(partitionData)
@@ -234,7 +252,6 @@ class Clickhouse extends BaseOutput {
     clickHouseProperties.getPort
   }
 
-
   private def getClickHouseSchema(conn: ClickHouseConnectionImpl, table: String): Map[String, String] = {
     val sql = s"desc $table"
     val resultSet = conn.createStatement.executeQuery(sql)
@@ -245,7 +262,9 @@ class Clickhouse extends BaseOutput {
     schema
   }
 
-  private def getClickHouseClusterInfo(conn: ClickHouseConnectionImpl, cluster: String): ArrayBuffer[(String, Int, Int, String, Int)] = {
+  private def getClickHouseClusterInfo(
+    conn: ClickHouseConnectionImpl,
+    cluster: String): ArrayBuffer[(String, Int, Int, String, Int)] = {
     val sql =
       s"SELECT cluster, shard_num, shard_weight, host_address FROM system.clusters WHERE cluster = '$cluster' AND replica_num = 1 order by shard_num"
     val resultSet = conn.createStatement.executeQuery(sql)

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/output/utils/ClickhouseUtil.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/output/utils/ClickhouseUtil.scala
@@ -1,0 +1,214 @@
+package io.github.interestinglab.waterdrop.output.utils
+
+import java.math.BigDecimal
+import java.sql.{Array, DriverManager, ResultSet}
+
+import io.github.interestinglab.waterdrop.output.batch.Clickhouse
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Row
+import ru.yandex.clickhouse.except.{ClickHouseException, ClickHouseUnknownException}
+import ru.yandex.clickhouse.{ClickHouseConnectionImpl, ClickHousePreparedStatement}
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.{Failure, Random, Success, Try}
+
+case class ClickhouseUtilParam(clusterInfo: ArrayBuffer[(String, Int, Int, String, Int)], database: String, user: String, password: String, initSql: String, tableSchema: Map[String, String], fields: List[String], shardingKey: String, batchSize: Int, retry: Int, retryCodes: List[Integer])
+
+
+class ClickhouseUtil(utilParam: ClickhouseUtilParam) extends Serializable with Logging {
+
+  private val rand = "rand()"
+
+  def getConnection(connectionInfo: (String, Int, Int, String, Int)): ClickHouseConnectionImpl = {
+    val host: String = connectionInfo._4
+    val port: Int = connectionInfo._5
+    val connectionHost = s"jdbc:clickhouse://$host:$port/${utilParam.database}"
+    logInfo(s"will connection to ${connectionHost}, user is ${utilParam.user}")
+    DriverManager.getConnection(connectionHost, utilParam.user, utilParam.password).asInstanceOf[ClickHouseConnectionImpl]
+  }
+
+  /**
+   * Add data, batch send
+   * if table is distributed, use sharding key get the value, choose the insert node. use the same connection for a batch of data.
+   * if the table is not a distributed table, randomly select a node.
+   *
+   * @param rows
+   */
+  def insertData(rows: Iterator[Row]): Unit = {
+    // each partition only create one connection with the node that needs to be inserted
+    var connection: ClickHouseConnectionImpl = null
+    var preparedStatement: ClickHousePreparedStatement = null
+    rows.grouped(utilParam.batchSize).foreach(batchData => {
+      batchData.foreach(row => {
+        if (preparedStatement == null) {
+          var index: Int = 0
+          if (utilParam.shardingKey == null || utilParam.shardingKey == rand) {
+            // for stand alone case or random sharding, randomly select a node
+            index = Random.nextInt(utilParam.clusterInfo.length)
+          } else {
+            index = getDistributedTableIndex(row)
+          }
+          val connectionInfo: (String, Int, Int, String, Int) = utilParam.clusterInfo(index)
+          connection = getConnection(connectionInfo)
+          preparedStatement = connection.createClickHousePreparedStatement(utilParam.initSql, ResultSet.TYPE_FORWARD_ONLY)
+        }
+        renderStatement(utilParam.fields, row, row.schema.fieldNames, preparedStatement)
+        preparedStatement.addBatch()
+      })
+      execute(preparedStatement, utilParam.retry)
+    })
+    if (preparedStatement != null) {
+      preparedStatement.close()
+    }
+    if (connection != null) {
+      connection.close()
+    }
+  }
+
+  private def getDistributedTableIndex(row: Row): Int = {
+    // for distributed table case. Use shard key to select insert node
+    // shardingKey is a numeric type, use Long
+    val shardingNumeric: AnyVal = row.getAs(utilParam.shardingKey)
+    var shardingValue: Long = 0L
+    shardingNumeric match {
+      case v: Int =>
+        shardingValue = v.asInstanceOf[Long]
+      case v: Long =>
+        shardingValue = v
+      case _ =>
+        throw new Exception("sharding key is not an Numeric!")
+    }
+    val index: Int = (shardingValue % utilParam.clusterInfo.size).intValue()
+    index
+  }
+
+  // todo need implement this method, return the index
+  private def intHash32Shard(shardingValue: Long): Int = {
+    1
+  }
+
+
+  private def intHash64Shard(shardingValue: Long): Int = {
+    1
+  }
+
+  private def execute(statement: ClickHousePreparedStatement, retry: Int): Unit = {
+    val res = Try(statement.executeBatch())
+    res match {
+      case Success(_) => {
+        logInfo("Insert into ClickHouse succeed")
+      }
+      case Failure(e: ClickHouseException) => {
+        val errorCode = e.getErrorCode
+        if (utilParam.retryCodes.contains(errorCode)) {
+          logError("Insert into ClickHouse failed. Reason: ", e)
+          if (retry > 0) {
+            execute(statement, retry - 1)
+          } else {
+            logError("Insert into ClickHouse failed and retry failed, drop this bulk.")
+            statement.close()
+          }
+        } else {
+          throw e
+        }
+      }
+      case Failure(e: ClickHouseUnknownException) => {
+        statement.close()
+        throw e
+      }
+      case Failure(e: Exception) => {
+        throw e
+      }
+    }
+  }
+
+  private def renderStatement(fields: List[String], item: Row, dsFields: scala.Array[String], statement: ClickHousePreparedStatement): Unit = {
+    for (i <- fields.indices) {
+      val field = fields(i)
+      val fieldType = utilParam.tableSchema(field)
+      if (dsFields.indexOf(field) == -1) {
+        // specified field does not existed in row.
+        renderDefaultStatement(i, fieldType, statement)
+      } else {
+        val fieldIndex = item.fieldIndex(field)
+        if (item.isNullAt(fieldIndex)) {
+          // specified field is Null in Row.
+          renderDefaultStatement(i, fieldType, statement)
+        } else {
+          renderStatementEntry(i, fieldIndex, fieldType, item, statement)
+        }
+      }
+    }
+  }
+
+  private def renderBaseTypeStatement(index: Int, fieldIndex: Int, fieldType: String, item: Row, statement: ClickHousePreparedStatement): Unit = {
+    fieldType match {
+      case "DateTime" | "Date" | "String" =>
+        statement.setString(index + 1, item.getAs[String](fieldIndex))
+      case "Int8" | "UInt8" | "Int16" | "UInt16" | "Int32" =>
+        statement.setInt(index + 1, item.getAs[Int](fieldIndex))
+      case "UInt32" | "UInt64" | "Int64" =>
+        statement.setLong(index + 1, item.getAs[Long](fieldIndex))
+      case "Float32" => statement.setFloat(index + 1, item.getAs[Float](fieldIndex))
+      case "Float64" => statement.setDouble(index + 1, item.getAs[Double](fieldIndex))
+      case Clickhouse.arrayPattern(_) =>
+        statement.setArray(index + 1, item(index).asInstanceOf[Array])
+      case "Decimal" => statement.setBigDecimal(index + 1, item.getAs[BigDecimal](fieldIndex))
+      case _ => statement.setString(index + 1, item.getAs[String](fieldIndex))
+    }
+  }
+
+  private def renderStatementEntry(index: Int, fieldIndex: Int, fieldType: String, item: Row, statement: ClickHousePreparedStatement): Unit = {
+    fieldType match {
+      case "String" | "DateTime" | "Date" | Clickhouse.arrayPattern(_) =>
+        renderBaseTypeStatement(index, fieldIndex, fieldType, item, statement)
+      case Clickhouse.floatPattern(_) | Clickhouse.intPattern(_) | Clickhouse.uintPattern(_) =>
+        renderBaseTypeStatement(index, fieldIndex, fieldType, item, statement)
+      case Clickhouse.nullablePattern(dataType) =>
+        renderStatementEntry(index, fieldIndex, dataType, item, statement)
+      case Clickhouse.lowCardinalityPattern(dataType) =>
+        renderBaseTypeStatement(index, fieldIndex, dataType, item, statement)
+      case Clickhouse.decimalPattern(_) =>
+        renderBaseTypeStatement(index, fieldIndex, "Decimal", item, statement)
+      case _ => statement.setString(index + 1, item.getAs[String](fieldIndex))
+    }
+  }
+
+
+  private def renderDefaultStatement(index: Int, fieldType: String, statement: ClickHousePreparedStatement): Unit = {
+    fieldType match {
+      case "DateTime" | "Date" | "String" =>
+        statement.setString(index + 1, Clickhouse.renderStringDefault(fieldType))
+      case "Int8" | "UInt8" | "Int16" | "Int32" | "UInt32" | "UInt16" =>
+        statement.setInt(index + 1, 0)
+      case "UInt64" | "Int64" =>
+        statement.setLong(index + 1, 0)
+      case "Float32" => statement.setFloat(index + 1, 0)
+      case "Float64" => statement.setDouble(index + 1, 0)
+      case Clickhouse.lowCardinalityPattern(lowCardinalityType) =>
+        renderDefaultStatement(index, lowCardinalityType, statement)
+      case Clickhouse.arrayPattern(_) => statement.setArray(index + 1, List().asInstanceOf[Array])
+      case Clickhouse.nullablePattern(nullFieldType) => renderNullStatement(index, nullFieldType, statement)
+      case _ => statement.setString(index + 1, "")
+    }
+  }
+
+  private def renderNullStatement(index: Int, fieldType: String, statement: ClickHousePreparedStatement): Unit = {
+    fieldType match {
+      case "String" =>
+        statement.setNull(index + 1, java.sql.Types.VARCHAR)
+      case "DateTime" => statement.setNull(index + 1, java.sql.Types.DATE)
+      case "Date" => statement.setNull(index + 1, java.sql.Types.TIME)
+      case "Int8" | "UInt8" | "Int16" | "Int32" | "UInt32" | "UInt16" =>
+        statement.setNull(index + 1, java.sql.Types.INTEGER)
+      case "UInt64" | "Int64" =>
+        statement.setNull(index + 1, java.sql.Types.BIGINT)
+      case "Float32" => statement.setNull(index + 1, java.sql.Types.FLOAT)
+      case "Float64" => statement.setNull(index + 1, java.sql.Types.DOUBLE)
+      case "Array" => statement.setNull(index + 1, java.sql.Types.ARRAY)
+      case Clickhouse.decimalPattern(_) => statement.setNull(index + 1, java.sql.Types.DECIMAL)
+    }
+  }
+
+
+}


### PR DESCRIPTION
when use clickhouse distributed table, maybe better insert data to each local_table. because when insert data to distributed table, the connect node will cache the data not belong to it, and send these parts data to the node belong. will cause secondary network transmission.
and on this update, not support use intHash as sharding strategy