### PR TITLE
Increase the file type and format of the package generated file

### DIFF
--- a/seatunnel-dist/assembly.xml
+++ b/seatunnel-dist/assembly.xml
@@ -19,9 +19,9 @@
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
-    <id>release</id>
+    <id>bin</id>
     <formats>
-        <format>zip</format>
+        <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>true</includeBaseDirectory>
     <fileSets>


### PR DESCRIPTION
Binary files are best to add the bin suffix
The package file is modified to tar.gz format