### PR TITLE
change es sink plugin index_type default value from log to _doc

### DIFF
--- a/plugin-spark-sink-elasticsearch/src/main/scala/io/github/interestinglab/waterdrop/spark/sink/Elasticsearch.scala
+++ b/plugin-spark-sink-elasticsearch/src/main/scala/io/github/interestinglab/waterdrop/spark/sink/Elasticsearch.scala
@@ -52,7 +52,7 @@ class Elasticsearch extends SparkBatchSink {
     val defaultConfig = ConfigFactory.parseMap(
       Map(
         "index" -> "waterdrop",
-        "index_type" -> "log",
+        "index_type" -> "_doc",
         "index_time_format" -> "yyyy.MM.dd"
       )
     )


### PR DESCRIPTION
---

## Purpose of this pull request
   Since Elasticsearch 6.0, the use of multiple types is gradually not recommended, and from Elasticsearch 7.0, the support for multiple types is gradually removed. The default type used in Elasticsearch 7.0 internal index is _doc, so it is recommended to change the default value of type to _doc for a more concise and fast configuration.
## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
The code of the critical link is not modified, only the default value of type is modified.
* [x] I will submit document change to https://github.com/InterestingLab/seatunnel-docs later
