### PR TITLE
[v1] added the abstraction of BaseAction

### DIFF
--- a/waterdrop-apis/src/main/scala/io/github/interestinglab/waterdrop/apis/BaseAction.java
+++ b/waterdrop-apis/src/main/scala/io/github/interestinglab/waterdrop/apis/BaseAction.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package io.github.interestinglab.waterdrop.apis;
+
+import io.github.interestinglab.waterdrop.config.Config;
+import org.apache.spark.SparkConf;
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Define an action to do whatever you want on execution started or finished,
+ * the sequence will be as follows:
+ *     program started ..
+ *     BaseAction::onExecutionStarted()
+ *       for loop for data:
+ *         Source --> Transform --> Sink
+ *     BaseAction::onExecutionFinished()
+ *     program finished ..
+ *
+ * Attention:
+ *   1. For now, this only apply for batch processing, not for streaming or structured streaming processing
+ * */
+public interface BaseAction extends Plugin {
+
+  void onExecutionStarted(SparkSession sparkSession, SparkConf sparkConf, Config config);
+
+  void onExecutionFinished(SparkConf sparkConf, Config config);
+}

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/Waterdrop.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/Waterdrop.scala
@@ -126,6 +126,11 @@ object Waterdrop extends Logging {
     // find all user defined UDFs and register in application init
     UdfRegister.findAndRegisterUdfs(sparkSession)
 
+    val actions = configBuilder.createActions[BaseAction]()
+    actions.foreach(act => {
+      act.onExecutionStarted(sparkSession, sparkConf, configBuilder.config)
+    })
+
     val staticInputs = configBuilder.createStaticInputs("batch")
     val streamingInputs = configBuilder.createStreamingInputs("batch")
     val filters = configBuilder.createFilters
@@ -137,6 +142,9 @@ object Waterdrop extends Logging {
       streamingProcessing(sparkSession, configBuilder, staticInputs, streamingInputs, filters, outputs)
     } else {
       batchProcessing(sparkSession, configBuilder, staticInputs, filters, outputs)
+      actions.foreach(act => {
+        act.onExecutionFinished(sparkConf, configBuilder.config)
+      })
     }
   }
 

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/config/ConfigBuilder.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/config/ConfigBuilder.scala
@@ -202,6 +202,29 @@ class ConfigBuilder(configFile: String) {
     outputList
   }
 
+  def createActions[T <: Plugin](): List[T] = {
+
+    var pluginInstances = List[T]()
+
+    config
+      .getConfigList("action")
+      .foreach(plugin => {
+
+        val className = buildClassFullQualifier(plugin.getString(ConfigBuilder.PluginNameKey), "action", "")
+
+        val obj = Class
+          .forName(className)
+          .newInstance()
+          .asInstanceOf[T]
+
+        obj.setConfig(plugin)
+
+        pluginInstances = pluginInstances :+ obj
+      })
+
+    pluginInstances
+  }
+
   private def getInputType(name: String, engine: String): String = {
     name match {
       case _ if name.toLowerCase.endsWith("stream") => {
@@ -230,6 +253,7 @@ class ConfigBuilder(configFile: String) {
         case "input" => ConfigBuilder.InputPackage + "." + getInputType(name, engine)
         case "filter" => ConfigBuilder.FilterPackage
         case "output" => ConfigBuilder.OutputPackage + "." + engine
+        case "action" => ConfigBuilder.ActionPackage
       }
 
       val services: Iterable[Plugin] =
@@ -267,6 +291,7 @@ object ConfigBuilder {
   val FilterPackage = PackagePrefix + ".filter"
   val InputPackage = PackagePrefix + ".input"
   val OutputPackage = PackagePrefix + ".output"
+  val ActionPackage = PackagePrefix + ".action"
 
   val PluginNameKey = "plugin_name"
 }


### PR DESCRIPTION
## Purpose of this pull request

  Define an action to do whatever you want on execution started or finished,
  the sequence will be as follows:
```
      program started ..
      BaseAction::onExecutionStarted()
        for loop for data:
          Source --> Transform --> Sink
      BaseAction::onExecutionFinished()
      program finished ..
 ```

  Attention:
    1. For now, this only apply for batch processing, not for streaming or structured streaming processing


## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] Change does not need document change, or I will submit document change to https://github.com/InterestingLab/seatunnel-docs later
