### PR TITLE
[SeaTunnel #836] [sql] Support set operation statements in sql configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,21 @@
                 <version>${flink.version}</version>
                 <scope>${flink.scope}</scope>
             </dependency>
+
+            <dependency>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-table-common</artifactId>
+                <version>${flink.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
+                <version>${flink.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
             <!--Because the license is not in compliance, if you need to use MySQL, you can add it yourself-->
             <dependency>
                 <groupId>mysql</groupId>

--- a/seatunnel-core/seatunnel-core-sql/pom.xml
+++ b/seatunnel-core/seatunnel-core-sql/pom.xml
@@ -33,7 +33,6 @@
     <properties>
         <flink.version>1.13.3</flink.version>
         <scala.binary.version>2.11</scala.binary.version>
-        <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
     <dependencies>
@@ -45,11 +44,6 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
-            <version>${flink.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-runtime-web_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
         </dependency>
         <dependency>
@@ -69,17 +63,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-csv</artifactId>
-            <version>${flink.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
-            <version>${flink.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-clients_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
         </dependency>
     </dependencies>

--- a/seatunnel-core/seatunnel-core-sql/src/main/java/io/github/interestinglab/waterdrop/core/sql/job/Executor.java
+++ b/seatunnel-core/seatunnel-core-sql/src/main/java/io/github/interestinglab/waterdrop/core/sql/job/Executor.java
@@ -18,6 +18,7 @@
 package io.github.interestinglab.waterdrop.core.sql.job;
 
 import io.github.interestinglab.waterdrop.core.sql.splitter.SqlStatementSplitter;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.StatementSet;
@@ -25,6 +26,7 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
 import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.command.SetOperation;
 
 import java.util.List;
 
@@ -46,17 +48,34 @@ public class Executor {
 
         StatementSet statementSet = tEnv.createStatementSet();
         TableEnvironmentImpl stEnv = (TableEnvironmentImpl) tEnv;
+        Configuration configuration = tEnv.getConfig().getConfiguration();
 
         List<String> stmts = SqlStatementSplitter.normalizeStatements(workFlowContent);
         for (String stmt : stmts) {
             Operation op = stEnv.getParser().parse(stmt).get(0);
             if (op instanceof CatalogSinkModifyOperation) {
                 statementSet.addInsertSql(stmt);
+            } else if (op instanceof SetOperation) {
+                callSetOperation(configuration, (SetOperation) op);
             } else {
                 tEnv.executeSql(stmt);
             }
         }
         return statementSet;
+    }
+
+    private static void callSetOperation(Configuration configuration, SetOperation setOperation) {
+
+        // set property
+        String key = setOperation.getKey()
+            .orElseThrow(() -> new IllegalArgumentException("key can not be empty!"))
+            .trim();
+
+        String value = setOperation.getValue()
+            .orElseThrow(() -> new IllegalArgumentException("value can not be empty!"))
+            .trim();
+
+        configuration.setString(key, value);
     }
 
 }


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/InterestingLab/seatunnel/issues).

  - Name the pull request in the form "[SeaTunnel #XXXX] [component] Title of the pull request", where *SeaTunnel #XXXX* should be replaced by the actual issue number.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

Fixed #836 

We need to start a standalone flink cluster first, then we can submit sql job in the past, beacuse the sql job is always run asynchronously by default. We can support set operation statements in sql configuration, like `SET table.dml-sync = true;` statement. After that we can run sql job in foreground.

Yeah, support run job in the foreground is just only one of the reasons for introducing this feature.

The keypoint of this feature is to support set operation.

## Run job local without startting cluster.
1. flink home
```
export FLINK_HOME=/work/BigData/install/flink/flink-1.13.3
```

2. application.conf
```
SET table.dml-sync = true;

CREATE TABLE events (
  f_type INT,
  f_uid INT,
  ts AS localtimestamp,
  WATERMARK FOR ts AS ts
) WITH (
  'connector' = 'datagen',
  'rows-per-second'='5',
  'fields.f_type.min'='1',
  'fields.f_type.max'='5',
  'fields.f_uid.min'='1',
  'fields.f_uid.max'='1000'
);

CREATE TABLE print_table (
  type INT,
  uid INT,
  lstmt TIMESTAMP
) WITH (
  'connector' = 'print',
  'sink.parallelism' = '1'
);

INSERT INTO print_table SELECT * FROM events where f_type = 1;
```

3. run local
```
bin/start-seatunnel-sql.sh --target local
```

4. result
```
[dcadmin@dcadmin seatunnel-dist-2.0.4-2.11.8]$ bin/start-seatunnel-sql.sh --target local
Job has been submitted with JobID 6d89f68da4c8f5f3e5c746fc595d44e7
+I[1, 457, 2021-12-20T16:09:06.476]
+I[1, 73, 2021-12-20T16:09:08.470]
+I[1, 736, 2021-12-20T16:09:08.470]
+I[1, 862, 2021-12-20T16:09:11.472]
+I[1, 953, 2021-12-20T16:09:11.472]
+I[1, 278, 2021-12-20T16:09:11.472]
+I[1, 63, 2021-12-20T16:09:13.472]
+I[1, 693, 2021-12-20T16:09:13.473]
```

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] Change does not need document change, or I will submit document change to https://github.com/InterestingLab/seatunnel-docs later
