### PR TITLE
[SeaTunnel #846] [docker] flink quick start demo run failed

### DIFF
--- a/deploy/docker/flink/README.md
+++ b/deploy/docker/flink/README.md
@@ -12,7 +12,7 @@ components are healthy, open your browser and navigate to http://localhost:8081,
 ## Start netcat as data source
 
 ```shell
-docker run -it --rm --network flink_local --name datasource alpine:3 nc -lk 9999
+docker run -it --rm --network flink_local --name datasource alpine:3 nc -lk -p 9999
 ```
 
 ## Submit SeaTunnel jobs
@@ -23,7 +23,7 @@ docker run -it --rm \
   -v $(pwd)/config/flink-conf.yaml:/flink/conf/flink-conf.yaml \
   --network flink_local \
   -e FLINK_PROPERTIES="jobmanager.rpc.address: jobmanager" \
-  apache/seatunnel-flink --config /app/application.conf
+  apache/seatunnel-flink --config /app/config/application.conf
 ```
 
 You will find the running job in http://localhost:8081.
@@ -35,5 +35,5 @@ Type some data in the `datasource` container of [the step](#start-netcat-as-data
 ## View the task manager logs
 
 ```shell
-docker-compose -f tskmanager
+docker-compose logs -f taskmanager
 ```


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/InterestingLab/seatunnel/issues).

  - Name the pull request in the form "[SeaTunnel #XXXX] [component] Title of the pull request", where *SeaTunnel #XXXX* should be replaced by the actual issue number.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

Fixed #846 

When run flink docker demo, met two exceptions

**1. Can not find the config file**
```
org.apache.flink.client.program.ProgramInvocationException: The main method caused an error: No configuration setting found for key 'env'
        at org.apache.flink.client.program.PackagedProgram.callMainMethod(PackagedProgram.java:593)
        at org.apache.flink.client.program.PackagedProgram.invokeInteractiveModeForExecution(PackagedProgram.java:438)
        at org.apache.flink.client.program.ClusterClient.run(ClusterClient.java:274)
        at org.apache.flink.client.cli.CliFrontend.executeProgram(CliFrontend.java:746)
        at org.apache.flink.client.cli.CliFrontend.runProgram(CliFrontend.java:273)
        at org.apache.flink.client.cli.CliFrontend.run(CliFrontend.java:205)
        at org.apache.flink.client.cli.CliFrontend.parseParameters(CliFrontend.java:1010)
        at org.apache.flink.client.cli.CliFrontend.lambda$main$10(CliFrontend.java:1083)
        at org.apache.flink.runtime.security.NoOpSecurityContext.runSecured(NoOpSecurityContext.java:30)
        at org.apache.flink.client.cli.CliFrontend.main(CliFrontend.java:1083)
Caused by: io.github.interestinglab.waterdrop.config.ConfigException$Missing: No configuration setting found for key 'env'
        at io.github.interestinglab.waterdrop.config.impl.SimpleConfig.findKeyOrNull(SimpleConfig.java:171)
        at io.github.interestinglab.waterdrop.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:191)
        at io.github.interestinglab.waterdrop.config.impl.SimpleConfig.find(SimpleConfig.java:203)
        at io.github.interestinglab.waterdrop.config.impl.SimpleConfig.find(SimpleConfig.java:208)
        at io.github.interestinglab.waterdrop.config.impl.SimpleConfig.getObject(SimpleConfig.java:283)
        at io.github.interestinglab.waterdrop.config.impl.SimpleConfig.getConfig(SimpleConfig.java:289)
        at io.github.interestinglab.waterdrop.config.impl.SimpleConfig.getConfig(SimpleConfig.java:55)
        at io.github.interestinglab.waterdrop.config.ConfigBuilder.createEnv(ConfigBuilder.java:183)
        at io.github.interestinglab.waterdrop.config.ConfigBuilder.<init>(ConfigBuilder.java:61)
        at io.github.interestinglab.waterdrop.Waterdrop.entryPoint(Waterdrop.java:102)
        at io.github.interestinglab.waterdrop.Waterdrop.run(Waterdrop.java:68)
        at io.github.interestinglab.waterdrop.WaterdropFlink.main(WaterdropFlink.java:30)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.flink.client.program.PackagedProgram.callMainMethod(PackagedProgram.java:576)
        ... 9 more
```

**2. Connection refused**
```
Caused by: java.lang.Exception: java.net.ConnectException: Connection refused (Connection refused)
        at org.apache.flink.streaming.runtime.tasks.SourceStreamTask$LegacySourceFunctionThread.checkThrowSourceExecutionException(SourceStreamTask.java:212)
        at org.apache.flink.streaming.runtime.tasks.SourceStreamTask.performDefaultAction(SourceStreamTask.java:132)
        at org.apache.flink.streaming.runtime.tasks.StreamTask.run(StreamTask.java:298)
        at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:403)
        at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:705)
        at org.apache.flink.runtime.taskmanager.Task.run(Task.java:530)
```

### SeaTunnel Version

dev

### SeaTunnel Config

```conf
env {
  execution.parallelism = 1
}

source {
  SocketStream{
    result_table_name = "fake"
    field_name = "info"
    host = "datasource"
  }
}

transform {
  Split{
    separator = "#"
    fields = ["name","age"]
  }
  sql {
    sql = "select * from (select info,split(info) as info_row from fake) t1"
  }
}

sink {
  ConsoleSink {}
}
```


### Running Command

```shell
docker-compose up -d
```


<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] Change does not need document change, or I will submit document change to https://github.com/InterestingLab/seatunnel-docs later
