### PR TITLE
[v1] [feature] add jdbc action

### DIFF
--- a/waterdrop-config/src/main/java/io/github/interestinglab/waterdrop/config/impl/ConfigParser.java
+++ b/waterdrop-config/src/main/java/io/github/interestinglab/waterdrop/config/impl/ConfigParser.java
@@ -126,7 +126,8 @@ final class ConfigParser {
                     || path.first().equals("output")
                     || path.first().equals("source")
                     || path.first().equals("transform")
-                    || path.first().equals("sink"))) {
+                    || path.first().equals("sink")
+                    || path.first().equals("action"))) {
                     v = parseObjectForWaterdrop((ConfigNodeObject)n);
                 } else {
                     v = parseObject((ConfigNodeObject)n);

--- a/waterdrop-core/src/main/resources/META-INF/services/io.github.interestinglab.waterdrop.apis.BaseAction
+++ b/waterdrop-core/src/main/resources/META-INF/services/io.github.interestinglab.waterdrop.apis.BaseAction
@@ -1,0 +1,1 @@
+io.github.interestinglab.waterdrop.action.Jdbc

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/action/Jdbc.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/action/Jdbc.scala
@@ -1,4 +1,4 @@
-package io.github.interestinglab.waterdrop.action.batch
+package io.github.interestinglab.waterdrop.action
 
 import java.sql.{Connection, DriverManager}
 
@@ -71,7 +71,7 @@ class Jdbc extends BaseAction {
 
   def executeSql(executeType: String): Unit = {
     val configList = config.getList(executeType)
-    if (configList.size() > 0) {
+    if (configList != null && configList.size() > 0) {
       val dataBaseConfig = getDataBaseConfig();
       val connection = getConnection(dataBaseConfig._1, dataBaseConfig._2, dataBaseConfig._3, dataBaseConfig._4)
       val statement = connection.createStatement()

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/action/Jdbc.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/action/Jdbc.scala
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.interestinglab.waterdrop.action
 
 import java.sql.{Connection, DriverManager, SQLException}

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/action/batch/Jdbc.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/action/batch/Jdbc.scala
@@ -1,15 +1,20 @@
 package io.github.interestinglab.waterdrop.action.batch
 
-import io.github.interestinglab.waterdrop.apis.BaseAction
+import java.sql.{Connection, DriverManager}
+
 import io.github.interestinglab.waterdrop.config.{Config, ConfigFactory}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
+import io.github.interestinglab.waterdrop.apis.BaseAction
+
+import scala.collection.JavaConverters._
+
 
 /**
  * Jdbc Action is able to specify driver class while Mysql Output's driver is bound to com.mysql.jdbc.Driver etc.
  * When using Jdbc Action, class of jdbc driver must can be found in classpath.
  * Jdbc Action supports at least: MySQL, Oracle, PostgreSQL, SQLite
-
+ * the sql executed can not return anything
  * */
 class Jdbc extends BaseAction {
 
@@ -52,11 +57,35 @@ class Jdbc extends BaseAction {
   }
 
   override def onExecutionStarted(sparkSession: SparkSession, sparkConf: SparkConf, config: Config): Unit = {
-    /*"beforeActions", "afterActions"*/
+    executeSql("beforeActions")
   }
 
   override def onExecutionFinished(sparkConf: SparkConf, config: Config): Unit = {
-    /*"beforeActions", "afterActions"*/
+    executeSql("afterActions")
   }
 
+  def getConnection(driver: String, url: String, user: String, password: String) : Connection = {
+    Class.forName(driver)
+    DriverManager.getConnection(url, user, password)
+  }
+
+  def executeSql(executeType: String): Unit = {
+    val configList = config.getList(executeType)
+    if (configList.size() > 0) {
+      val dataBaseConfig = getDataBaseConfig();
+      val connection = getConnection(dataBaseConfig._1, dataBaseConfig._2, dataBaseConfig._3, dataBaseConfig._4)
+      val statement = connection.createStatement()
+      configList.asScala.foreach(sql => statement.execute(sql.unwrapped().toString))
+      statement.close()
+      connection.close()
+    }
+  }
+
+  def getDataBaseConfig(): (String, String, String, String) = {
+    val driver = config.getString("driver")
+    val url = config.getString("url")
+    val user = config.getString("user")
+    val password = config.getString("password")
+    (driver, url, user, password)
+  }
 }

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/action/batch/Jdbc.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/action/batch/Jdbc.scala
@@ -1,0 +1,67 @@
+package io.github.interestinglab.waterdrop.action.batch
+
+import io.github.interestinglab.waterdrop.apis.BaseAction
+import io.github.interestinglab.waterdrop.config.{Config, ConfigFactory}
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Jdbc Action is able to specify driver class while Mysql Output's driver is bound to com.mysql.jdbc.Driver etc.
+ * When using Jdbc Action, class of jdbc driver must can be found in classpath.
+ * Jdbc Action supports at least: MySQL, Oracle, PostgreSQL, SQLite
+
+ * */
+class Jdbc extends BaseAction {
+
+  var firstProcess = true
+  var config: Config = ConfigFactory.empty()
+
+  /**
+   * Set Config.
+   * */
+  override def setConfig(config: Config): Unit = {
+    this.config = config
+  }
+
+  /**
+   * Get Config.
+   * */
+  override def getConfig(): Config = {
+    this.config
+  }
+
+  override def checkConfig(): (Boolean, String) = {
+
+    // TODO: are user, password required ?
+    val requiredOptions = List("driver", "url", "table", "user", "password");
+    val nonExistsOptions = requiredOptions.map(optionName => (optionName, config.hasPath(optionName))).filter { p =>
+      val (optionName, exists) = p
+      !exists
+    }
+
+    if (nonExistsOptions.length == 0) {
+      val saveModeAllowedValues = List("overwrite", "append", "ignore", "error");
+      if (!config.hasPath("save_mode") || saveModeAllowedValues.contains(config.getString("save_mode"))) {
+        (true, "")
+      } else {
+        (false, "wrong value of [save_mode], allowed values: " + saveModeAllowedValues.mkString(", "))
+      }
+
+    } else {
+      (
+        false,
+        "please specify " + nonExistsOptions
+          .map { option =>
+            val (name, exists) = option
+            "[" + name + "]"
+          }
+          .mkString(", ") + " as non-empty string"
+      )
+    }
+  }
+
+  override def onExecutionStarted(sparkSession: SparkSession, sparkConf: SparkConf, config: Config): Unit = ???
+
+  override def onExecutionFinished(sparkConf: SparkConf, config: Config): Unit = ???
+
+}

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/action/batch/Jdbc.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/action/batch/Jdbc.scala
@@ -32,22 +32,12 @@ class Jdbc extends BaseAction {
 
   override def checkConfig(): (Boolean, String) = {
 
-    // TODO: are user, password required ?
-    val requiredOptions = List("driver", "url", "table", "user", "password");
+    val requiredOptions = List("driver", "url", "user", "password")
     val nonExistsOptions = requiredOptions.map(optionName => (optionName, config.hasPath(optionName))).filter { p =>
       val (optionName, exists) = p
       !exists
     }
-
-    if (nonExistsOptions.length == 0) {
-      val saveModeAllowedValues = List("overwrite", "append", "ignore", "error");
-      if (!config.hasPath("save_mode") || saveModeAllowedValues.contains(config.getString("save_mode"))) {
-        (true, "")
-      } else {
-        (false, "wrong value of [save_mode], allowed values: " + saveModeAllowedValues.mkString(", "))
-      }
-
-    } else {
+    if (nonExistsOptions.nonEmpty) {
       (
         false,
         "please specify " + nonExistsOptions
@@ -58,10 +48,15 @@ class Jdbc extends BaseAction {
           .mkString(", ") + " as non-empty string"
       )
     }
+    (true, "")
   }
 
-  override def onExecutionStarted(sparkSession: SparkSession, sparkConf: SparkConf, config: Config): Unit = ???
+  override def onExecutionStarted(sparkSession: SparkSession, sparkConf: SparkConf, config: Config): Unit = {
+    /*"beforeActions", "afterActions"*/
+  }
 
-  override def onExecutionFinished(sparkConf: SparkConf, config: Config): Unit = ???
+  override def onExecutionFinished(sparkConf: SparkConf, config: Config): Unit = {
+    /*"beforeActions", "afterActions"*/
+  }
 
 }

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/config/ConfigBuilder.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/config/ConfigBuilder.scala
@@ -269,7 +269,8 @@ class ConfigBuilder(configFile: String) {
           (ServiceLoader load classOf[BaseOutput]).asScala ++
           (ServiceLoader load classOf[BaseStructuredStreamingInput]).asScala ++
           (ServiceLoader load classOf[BaseStructuredStreamingOutput]).asScala ++
-          (ServiceLoader load classOf[BaseStructuredStreamingOutputIntra])
+          (ServiceLoader load classOf[BaseStructuredStreamingOutputIntra]).asScala ++
+          (ServiceLoader load classOf[BaseAction]).asScala
 
       var classFound = false
       breakable {

--- a/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/config/ConfigBuilder.scala
+++ b/waterdrop-core/src/main/scala/io/github/interestinglab/waterdrop/config/ConfigBuilder.scala
@@ -71,6 +71,7 @@ class ConfigBuilder(configFile: String) {
     val streamingInputs = this.createStreamingInputs("streaming")
     val outputs = this.createOutputs[BaseOutput]("batch")
     val filters = this.createFilters
+    val actions = this.createActions
   }
 
   def getSparkConfigs: Config = {


### PR DESCRIPTION

## Purpose of this pull request


add jdbc action
Users can use this feature to execute some SQL before the data is imported and some SQL after the data is imported.

```
action {
   jdbc {
    driver = "com.mysql.jdbc.Driver"
    url = "jdbc:mysql://localhost:3306/databasename"
    user = "xxx"
    password = "xxxx"
    before {
       errorSqlIgnored = true //default false
       actions = [
           "create table my_tb4 (id varchar(5))"
           "create table my_tb5 (id varchar(5))"
       ]
    }
    after {
       errorSqlIgnored = true //default false
       actions = [
           "show tables"
       ]
    }
   }
}
```

## Check list

* [x] Code changed are covered with tests, or it does not need tests for reason:
* [x] Change does not need document change, or I will submit document change to https://github.com/InterestingLab/seatunnel-docs later
